### PR TITLE
Update paralogs.sh

### DIFF
--- a/cluster_scripts/paralogs.sh
+++ b/cluster_scripts/paralogs.sh
@@ -89,7 +89,7 @@ do
 	
 	while read j
 	do
-		nom=$(echo $j | cut -c3-9)
+		nom=$(echo $j | sed -e 's/^.\///' | sed -e 's/\/[[:graph:]]*//')
 		cp $j ${i}_fastas/${nom}.fasta
 	done < ${i}_paralog_fasta_list.txt
 


### PR DESCRIPTION
Changed from "keep what is between 3rd and 9th character" to "remove "./" and then remove "/[anycharacter(s)]". It is to avoid malfunctioning when the names in namelist.txt doesn't match the I##_T## pattern (ie when names are more than 8 characters).